### PR TITLE
Small bugfix related to ensemble and min/max of terra

### DIFF
--- a/R/ensemble.R
+++ b/R/ensemble.R
@@ -217,7 +217,7 @@ methods::setMethod(
           ras_uncertainty <- switch (uncertainty,
                                      "sd" = terra::app(ras, sd, na.rm = TRUE),
                                      "cv" = terra::app(ras, sd, na.rm = TRUE) / terra::mean(ras, na.rm = TRUE),
-                                     "range" = terra::max(ras, na.rm = TRUE) - terra::min(ras, na.rm = TRUE),
+                                     "range" = max(ras, na.rm = TRUE) - min(ras, na.rm = TRUE),
                                      "pca" = terra::mean(rasp, na.rm = TRUE)
           )
           names(ras_uncertainty) <- paste0(uncertainty, "_", lyr)
@@ -300,7 +300,7 @@ methods::setMethod(
         ras_uncertainty <- switch (uncertainty,
                                    "sd" = terra::app(ras, fun = "sd", na.rm = TRUE),
                                    "cv" = terra::app(ras, fun = "sd", na.rm = TRUE) / terra::mean(ras, na.rm = TRUE),
-                                   "range" = terra::max(ras, na.rm = TRUE) - terra::min(ras, na.rm = TRUE)
+                                   "range" = max(ras, na.rm = TRUE) - min(ras, na.rm = TRUE)
         )
         names(ras_uncertainty) <- paste0(uncertainty, "_", lyr)
         # Add attributes on the method of ensembling


### PR DESCRIPTION
Not sure if that's related to some strange `NAMESPACE` issue and `terra` on my side, but the original code on `dev` returns `Error: 'max' is not an exported object from 'namespace:terra'` for me when using `ensemble()` and the range as uncertainty meausre. However, runs fine if `min()` and `max()` are not specified from the `terra` `NAMESPACE`