### PR TITLE
Replace 'rgeos' with 'terra' in installation

### DIFF
--- a/vignettes/articles/02_train_simple_model.Rmd
+++ b/vignettes/articles/02_train_simple_model.Rmd
@@ -53,7 +53,7 @@ install <- function(packages){
 if(!("INLA" %in% installed.packages()[, "Package"])){
   install.packages("INLA",repos=c(getOption("repos"),INLA="https://inla.r-inla-download.org/R/stable"), dep=TRUE)
 }
-install(c("inlabru", "xgboost", "rgeos", "igraph"))
+install(c("inlabru", "xgboost", "terra", "igraph"))
 ```
 
 


### PR DESCRIPTION
The 'rgeos' package was [removed from the CRAN repository and archived on 2023-10-16](https://cran.r-project.org/web/packages/rgeos/index.html), leading to installation errors. 

This commit updates the installation statement in the official tutorial to use the 'terra' package as an alternative. Users can now successfully install the package without encountering issues related to the deprecated 'rgeos' package.

👉 Fixed: 'rgeos' installation error.
✅ Tested: "02-Train a basic model.Rmd" runs successfully. 