### PR TITLE
Fix clamp

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -459,7 +459,7 @@ clamp_predictions <- function(model, pred){
     o2 <- aggregate(vars_clamp$max, by = list(vars_clamp$variable), FUN = max)
     names(o1) <- c("variable", "min")
     names(o2) <- c("variable", "max")
-    vars_clamp2 <- merge(o1, o2)
+    vars_clamp <- merge(o1, o2)
   }
   # --- #
   # Now clamp either predictors

--- a/R/utils.R
+++ b/R/utils.R
@@ -452,13 +452,14 @@ clamp_predictions <- function(model, pred){
     vars_clamp <- rbind(vars_clamp, rr)
     rm(rr)
   }
+
   # Aggregate if multiple variables
-  if(anyDuplicated(vars_clamp$variable)){
-    o1 <- aggregate(variable ~ min, data = vars_clamp,
-              FUN = function(x) min(x) )
-    o2 <- aggregate(variable ~ max, data = vars_clamp,
-                    FUN = function(x) max(x) )
-    vars_clamp <- merge(o1,o2)
+  if(anyDuplicated(vars_clamp$variable) > 0){
+    o1 <- aggregate(vars_clamp$min, by = list(vars_clamp$variable), FUN = min)
+    o2 <- aggregate(vars_clamp$max, by = list(vars_clamp$variable), FUN = max)
+    names(o1) <- c("variable", "min")
+    names(o2) <- c("variable", "max")
+    vars_clamp2 <- merge(o1, o2)
   }
   # --- #
   # Now clamp either predictors

--- a/R/utils.R
+++ b/R/utils.R
@@ -467,8 +467,8 @@ clamp_predictions <- function(model, pred){
   # Now clamp the prediction matrix with the clamped variables
   for (v in intersect(vars_clamp$variable, names(pred))) {
     pred[, v] <- pmin(
-      pmax(pred[, v], vars_clamp$min[vars_clamp==v] ),
-      vars_clamp$max[vars_clamp==v])
+      pmax(pred[, v], vars_clamp$min[vars_clamp$variable==v] ),
+      vars_clamp$max[vars_clamp$variable==v])
   }
 
   assertthat::assert_that( is.data.frame(pred) || is.matrix(pred),


### PR DESCRIPTION
This PR aims to fix a bug related to clamping model predictions (see #102). 

Briefly, it seems that the original code using `aggregate()` did not always collapse/aggregate duplicated rows/values (per the `variable` column) for the `vars_clamp` object. As such, although the `vars_clamp` object should not contain multiple rows after processing it with `aggregate()` to get it ready for the actual clamping code, the `vars_clamp` object actually did contain multiple rows with the same values in the `variable` column. This meant that the `pmax()` and `pmin()` functions used later to clamp the prediction data (i.e., `pred` object) would apply different upper and lower thresholds to different observations/rows/pixels in the prediciton data -- as opposed to using a single upper and lower threshold per variable across all observations/rows/pixels in the prediction data. To address this, I have modified the code so that it uses `aggregate()` slightly differently - I don't really know why the original code wasn't working, but it seems to work now. Perhaps this is something to do with how R converts character vectors to factors or something? 

Here's a reprex:

```
# load packages
devtools::load_all()
library(terra)
library(dplyr)

# set seed
set.seed(500)

# load data
bg_data <- 
  system.file("extdata/europegrid_50km.tif", package = "ibis.iSDM") |>
  terra::rast()
spp_data <- 
  system.file("extdata/input_data.gpkg", package = "ibis.iSDM") |>
  sf::read_sf()
env_data <- 
  system.file("extdata/predictors/", package = "ibis.iSDM") |>
  list.files("*.tif", full.names = TRUE) |>
  terra::rast()

# create absences
psa_sett <- 
  bg_data |>
  pseudoabs_settings(
    nrpoints = 50, 
    method = "mcp",
    inside = FALSE
  )
abs_data <- 
  spp_data |>
  add_pseudoabsence(field_occurrence = "Observed", settings = psa_sett) |>
  filter(type == "Pseudo-absence")

# create presence-only data
spp_data$pres_only <- 
  sample(c(TRUE, FALSE), size = nrow(spp_data), replace = TRUE)
pres_only_data <-
  spp_data |>
  filter(pres_only) |>
  select(-pres_only) |>
  slice_head(n = 50)

# create presence-absence data
pres_abs_data <-
  spp_data |>
  filter(!pres_only) |>
  select(-pres_only) |>
  slice_head(n = 50) |>
  bind_rows(abs_data)

# define model specification
## simple model fit with presence/absence data
model <- 
  distribution(bg_data) |>  
  add_predictors(env = env_data, transform = "scale", derivates = "none")  |> 
  add_biodiversity_poipo(pres_only_data, field_occurrence = "Observed") |>  
  add_biodiversity_poipa(pres_abs_data, field_occurrence = "Observed") |>  
  engine_inlabru()

# fit model and clamp predictions
fit <- train(model, clamp = TRUE)

# display warnings
## note we expect one warning from sf::read_sf()
warnings()
```

Also, if you merge this PR, I suggest squashing the commits during the merge process to aovid polluting the commit history with my failed atttempts to fix the issue. 