### PR TITLE
project for method_integration = "predictor"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 #### New features
 * Add functions that creates HTML file base on `DistributionModel`.
 * Added new engine `engine_scampr()` for model-based integration.
+* Allow projection of models using `method_integration = "predictor"`
 
 #### Minor improvements and bug fixes
 * Small fixes to ensure `boruta` filtering works (again)?

--- a/R/add_biodiversity.R
+++ b/R/add_biodiversity.R
@@ -130,7 +130,7 @@ methods::setMethod(
 
     # Create a new biodiversity dataset
     bd <- BiodiversityDataset$new(
-      name = ifelse(is.null(name), "Species: ",name),
+      name = ifelse(is.null(name), substring(id[[1]], 1, 8), name),
       id = id,
       equation = formula,
       family = family,
@@ -268,7 +268,7 @@ methods::setMethod(
 
     # Define the biodiversity object
     bd <- BiodiversityDataset$new(
-      name = ifelse(is.null(name), "Species: ",name),
+      name = ifelse(is.null(name), substring(id[[1]], 1, 8), name),
       id = id,
       equation = formula,
       family = family,
@@ -460,7 +460,7 @@ methods::setMethod(
 
       # Define the biodiversity object
       bd <- BiodiversityDataset$new(
-        name = ifelse(is.null(name), "Species: ",name),
+        name = ifelse(is.null(name), substring(id[[1]], 1, 8), name),
         id = id,
         equation = formula,
         family = family,
@@ -681,7 +681,7 @@ methods::setMethod(
 
       # Define the biodiversity object
       bd <- BiodiversityDataset$new(
-        name = ifelse(is.null(name), "Species: ",name),
+        name = ifelse(is.null(name), substring(id[[1]], 1, 8), name),
         id = id,
         equation = formula,
         family = family,

--- a/R/add_predictors.R
+++ b/R/add_predictors.R
@@ -765,7 +765,8 @@ methods::setMethod(
       }
     # some predictors also in .interals object
     } else {
-      pred_tmp <- c(model$predictors_names, c(sapply(obj$.internals, function(i) i$model$model$predictors_names)))
+      pred_tmp <- c(model$predictors_names, unlist(sapply(obj$.internals, function(i) i$model$model$predictors_names),
+                                                   use.names = FALSE))
       if(length(names(env)) > length(pred_tmp) - 1) {
         if(getOption('ibis.setupmessages', default = TRUE)){
           myLog('[Scenario]','yellow','Found less variables in fitted model than in scenarios object. Subsetting...')

--- a/R/add_predictors.R
+++ b/R/add_predictors.R
@@ -765,7 +765,7 @@ methods::setMethod(
       }
     # some predictors also in .interals object
     } else {
-      pred_tmp <- c(model$predictors_names, c(sapply(obj$.internals, function(i) i$predictors_names)))
+      pred_tmp <- c(model$predictors_names, c(sapply(obj$.internals, function(i) i$model$predictors_names)))
       if(length(names(env)) > length(pred_tmp) - 1) {
         if(getOption('ibis.setupmessages', default = TRUE)){
           myLog('[Scenario]','yellow','Found less variables in fitted model than in scenarios object. Subsetting...')

--- a/R/add_predictors.R
+++ b/R/add_predictors.R
@@ -755,11 +755,10 @@ methods::setMethod(
     model <- obj$model
 
     # Subset to target predictors only
-    if(length(model$predictors_names) != length(names(env))){
+    if(length(names(env)) > length(model$predictors_names)) {
       if(getOption('ibis.setupmessages', default = TRUE)) myLog('[Scenario]','yellow','Found less variables in fitted model than supplied. Subsetting...')
       env <- env |> dplyr::select(dplyr::any_of(model$predictors_names))
-      assertthat::assert_that(length(env)>0,
-                              msg = "No matching variables found!")
+      assertthat::assert_that(length(env)>0, msg = "No matching variables found!")
     }
 
     # Get state if not set

--- a/R/add_predictors.R
+++ b/R/add_predictors.R
@@ -765,7 +765,7 @@ methods::setMethod(
       }
     # some predictors also in .interals object
     } else {
-      pred_tmp <- c(model$predictors_names, c(sapply(obj$.internals, function(i) i$model$predictors_names)))
+      pred_tmp <- c(model$predictors_names, c(sapply(obj$.internals, function(i) i$model$model$predictors_names)))
       if(length(names(env)) > length(pred_tmp) - 1) {
         if(getOption('ibis.setupmessages', default = TRUE)){
           myLog('[Scenario]','yellow','Found less variables in fitted model than in scenarios object. Subsetting...')

--- a/R/class-distributionmodel.R
+++ b/R/class-distributionmodel.R
@@ -21,6 +21,7 @@ DistributionModel <- R6::R6Class(
     #' @field model A [`list`] containing all input datasets and parameters to the model.
     #' @field settings A [`Settings-class`] object with information on inference.
     #' @field fits A [`list`] containing the prediction and fitted model.
+    #' @field .internals A [`list`] containing previous fitted models.
     id = character(),
     name = character(),
     model = list(),

--- a/R/class-distributionmodel.R
+++ b/R/class-distributionmodel.R
@@ -24,9 +24,9 @@ DistributionModel <- R6::R6Class(
     id = character(),
     name = character(),
     model = list(),
-    model_int = new_waiver(),
     settings = new_waiver(),
     fits = list(),
+    .internals = new_waiver(),
 
     #' @description
     #' Initializes the object and creates an empty list

--- a/R/class-distributionmodel.R
+++ b/R/class-distributionmodel.R
@@ -24,6 +24,7 @@ DistributionModel <- R6::R6Class(
     id = character(),
     name = character(),
     model = list(),
+    model_int = new_waiver(),
     settings = new_waiver(),
     fits = list(),
 

--- a/R/project.R
+++ b/R/project.R
@@ -248,7 +248,7 @@ methods::setMethod(
                             utils::hasName(df,'x'), utils::hasName(df,'y'), utils::hasName(df,'time'),
                             msg = "Error: Projection data and training data are not of equal size and format!")
 
-    df <- dplyr::select(df, dplyr::any_of(c("x", "y", "time", unlist(int_pred_names, use.name = FALSE),
+    df <- dplyr::select(df, dplyr::any_of(c("x", "y", "time", unlist(int_pred_names, use.names = FALSE),
                                             mod_pred_names)))
     df$time <- to_POSIXct(df$time)
     # Convert all units classes to numeric or character to avoid problems

--- a/R/project.R
+++ b/R/project.R
@@ -128,6 +128,7 @@ methods::setMethod(
     # Get predictors
     new_preds <- mod$get_predictors()
     if(is.Waiver(new_preds)) stop('No scenario predictors found.')
+
     new_crs <- new_preds$get_projection()
     if(is.na(new_crs)) if(getOption('ibis.setupmessages', default = TRUE)) myLog('[Scenario]','yellow','Missing projection of future predictors.')
 
@@ -172,8 +173,20 @@ methods::setMethod(
     # Check that predictor names are all present.
     mod_pred_names <- fit$model$predictors_names
     pred_names <- mod$get_predictor_names()
-    assertthat::assert_that( all(mod_pred_names %in% pred_names),
-                             msg = paste0('Model predictors are missing from the scenario predictor!') )
+    # get predictor names of integrated model
+    if (!is.Waiver(fit$.internals)) {
+      int_pred_names <- lapply(fit$.internals, function(i) i$model$model$predictors_names)
+    } else (int_pred_names <- NULL)
+
+    if (is.Waiver(fit$.internals)) {
+      assertthat::assert_that(all(mod_pred_names %in% pred_names),
+                              msg = paste0('Model predictors are missing from the scenario predictor!'))
+    } else {
+      # check if missing preds are in .internals list
+      assertthat::assert_that(sum(!mod_pred_names %in% pred_names) == 1 ||
+                                any(!unlist(int_pred_names, use.names = FALSE) %in% pred_names),
+                              msg = "Model predictors are missing from the scenario predictor!")
+    }
 
     # Get constraints, threshold values and other parameters
     scenario_threshold <- mod$get_threshold()
@@ -235,8 +248,9 @@ methods::setMethod(
                             utils::hasName(df,'x'), utils::hasName(df,'y'), utils::hasName(df,'time'),
                             msg = "Error: Projection data and training data are not of equal size and format!")
 
-    df <- subset(df, select = c("x", "y", "time", mod_pred_names) )
-    df$time <- to_POSIXct( df$time )
+    df <- dplyr::select(df, dplyr::any_of(c("x", "y", "time", unlist(int_pred_names, use.name = FALSE),
+                                            mod_pred_names)))
+    df$time <- to_POSIXct(df$time)
     # Convert all units classes to numeric or character to avoid problems
     df <- units::drop_units(df)
 
@@ -252,13 +266,17 @@ methods::setMethod(
       pb <- progress::progress_bar$new(format = "Creating projections (:spin) [:bar] :percent",
                                        total = length(unique(df$time)))
     }
+
     # TODO: Consider doing this in parallel but sequential
     times <- sort(unique(df$time))
-    for(step in times){ # step = times[1]
+
+    for(step in times){
+
       # Get data
       nd <- subset(df, time == step)
-      assertthat::assert_that(nrow(nd)>0,
-                              !all(is.na(nd[, mod_pred_names])) )
+
+      # check that timestep has data
+      assertthat::assert_that(nrow(nd)>0, !all(is.na(dplyr::select(nd, dplyr::any_of(mod_pred_names)))))
 
       # Apply adaptability constrain
       if("adaptability" %in% names(scenario_constraints)){
@@ -271,8 +289,29 @@ methods::setMethod(
         }
       }
 
+      # loop through integrated models
+      if (!is.Waiver(fit$.internals)) {
+
+        int_proj <- vector(mode = "list", length = length(fit$.internals))
+
+        # loop through all internals
+        for (i in 1:length(fit$.internals)) {
+
+          pred_tmp <- c("x", "y", fit$.internals[[i]]$model$model$predictors_names)
+          proj_tmp <- fit$.internals[[i]]$model$project(newdata = dplyr::select(nd, dplyr::any_of(pred_tmp)),
+                                                        layer = layer)
+          names(proj_tmp) <- fit$.internals[[i]]$name
+
+          # add to next nd
+          nd <- dplyr::left_join(x = nd, y = terra::as.data.frame(proj_tmp, xy = TRUE),
+                                 by = c("x", "y"))
+
+        }
+      }
+
       # Project suitability
-      out <- fit$project(newdata = nd, layer = layer)
+      pred_tmp <- c("x", "y", fit$model$predictors_names)
+      out <- fit$project(newdata = dplyr::select(nd, dplyr::any_of(pred_tmp)), layer = layer)
       names(out) <- paste0("suitability", "_", layer, "_", as.numeric(step))
       if(is.na(terra::crs(out))) terra::crs(out) <- terra::crs( background )
 

--- a/R/scenario.R
+++ b/R/scenario.R
@@ -90,7 +90,6 @@ methods::setMethod(
     }
     # Create BiodiversityScenario object
     sc <- BiodiversityScenario$new()
-    sc$t <- modelobject
     sc$modelobject <- modelobject
     sc$modelid <- modelid
     sc$limits <- limits

--- a/R/train.R
+++ b/R/train.R
@@ -972,9 +972,6 @@ methods::setMethod(
 
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
-        if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- out
-        }
         rm(model2, settings2)
 
         # Add Prediction of model to next object if multiple are supplied
@@ -1019,7 +1016,10 @@ methods::setMethod(
                 model$biodiversity[[other_id]]$equation <- ff
               } # Else skip
             }
-
+            # add to internals
+            if (!is.Waiver(.internals) && id != ids[length(ids)]) {
+              .internals[[id]] <- list(model = out, name = pred_name)
+            }
           } else if(method_integration == "offset"){
             # Adding the prediction as offset
             new <- out$get_data("prediction")
@@ -1100,9 +1100,6 @@ methods::setMethod(
 
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
-        if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- out
-        }
         rm(model2, settings2)
 
         # Add Prediction of model to next object if multiple are supplied
@@ -1146,7 +1143,10 @@ methods::setMethod(
                 model$biodiversity[[other_id]]$equation <- ff
               } # Else skip
             }
-
+            # add to internals
+            if (!is.Waiver(.internals) && id != ids[length(ids)]) {
+              .internals[[id]] <- list(model = out, name = pred_name)
+            }
           } else if(method_integration == "offset"){
             # Adding the prediction as offset
             new <- out$get_data("prediction")
@@ -1226,10 +1226,6 @@ methods::setMethod(
 
         out <- x$engine$train(model2, settings2)
         rm(model2, settings2)
-        # save previous outs
-        if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- out
-        }
 
         # Add Prediction of model to next object if multiple are supplied
         if(length(ids)>1 && id != ids[length(ids)]){
@@ -1273,7 +1269,10 @@ methods::setMethod(
                 model$biodiversity[[other_id]]$equation <- ff
               } # Else skip
             }
-
+            # add to internals
+            if (!is.Waiver(.internals) && id != ids[length(ids)]) {
+              .internals[[id]] <- list(model = out, name = pred_name)
+            }
           } else if(method_integration == "offset"){
             # Adding the prediction as offset
             new <- out$get_data("prediction")[["mean"]]
@@ -1378,9 +1377,6 @@ methods::setMethod(
 
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
-        if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- out
-        }
         rm(model2, settings2)
 
         # Add Prediction of model to next object if multiple are supplied
@@ -1424,7 +1420,10 @@ methods::setMethod(
                 model$biodiversity[[other_id]]$equation <- ff
               } # Else skip
             }
-
+            # add to internals
+            if (!is.Waiver(.internals) && id != ids[length(ids)]) {
+              .internals[[id]] <- list(model = out, name = pred_name)
+            }
           } else if(method_integration == "offset"){
             # Adding the prediction as offset
             new <- out$get_data("prediction")
@@ -1500,9 +1499,6 @@ methods::setMethod(
 
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
-        if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- out
-        }
         rm(model2, settings2)
 
         # Add Prediction of model to next object if multiple are supplied
@@ -1545,7 +1541,10 @@ methods::setMethod(
                 model$biodiversity[[other_id]]$equation <- ff
               } # Else skip
             }
-
+            # add to internals
+            if (!is.Waiver(.internals) && id != ids[length(ids)]) {
+              .internals[[id]] <- list(model = out, name = pred_name)
+            }
           } else if(method_integration == "offset"){
             # Adding the prediction as offset
             new <- out$get_data("prediction")
@@ -1620,9 +1619,6 @@ methods::setMethod(
 
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
-        if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- out
-        }
         rm(model2, settings2)
 
         # Add Prediction of model to next object if multiple are supplied
@@ -1665,7 +1661,10 @@ methods::setMethod(
                 model$biodiversity[[other_id]]$equation <- ff
               } # Else skip
             }
-
+            # add to internals
+            if (!is.Waiver(.internals) && id != ids[length(ids)]) {
+              .internals[[id]] <- list(model = out, name = pred_name)
+            }
           } else if(method_integration == "offset"){
             # Adding the prediction as offset
             new <- out$get_data("prediction")

--- a/R/train.R
+++ b/R/train.R
@@ -57,6 +57,8 @@ NULL
 #' then combined for estimation and weighted respectively, thus giving for example
 #' presence-only records less weight than survey records. **Note** that this parameter
 #' is ignored for engines that support joint likelihood estimation.
+#' @param keep_models [`logical`] if true and `method_integration = "predictor"`,
+#' all models are stored in the `.internal` list of the model object.
 #' @param aggregate_observations [`logical`] on whether observations covering the
 #' same grid cell should be aggregated (Default: \code{TRUE}).
 #' @param clamp [`logical`] whether predictions should be clamped to the range
@@ -149,7 +151,7 @@ methods::setGeneric(
   "train",
   signature = methods::signature("x"),
   function(x, runname, filter_predictors = "none", optim_hyperparam = FALSE, inference_only = FALSE,
-           only_linear = TRUE, method_integration = "predictor",
+           only_linear = TRUE, method_integration = "predictor", keep_models = TRUE,
            aggregate_observations = TRUE, clamp = FALSE, verbose = getOption('ibis.setupmessages', default = TRUE),...) standardGeneric("train"))
 
 #' @rdname train
@@ -157,7 +159,7 @@ methods::setMethod(
   "train",
   methods::signature(x = "BiodiversityDistribution"),
   function(x, runname, filter_predictors = "none", optim_hyperparam = FALSE, inference_only = FALSE,
-           only_linear = TRUE, method_integration = "predictor",
+           only_linear = TRUE, method_integration = "predictor", keep_models = TRUE,
            aggregate_observations = TRUE, clamp = TRUE, verbose = getOption('ibis.setupmessages', default = TRUE),...) {
     if(missing(runname)) runname <- "Unnamed run"
 
@@ -846,7 +848,8 @@ methods::setMethod(
     ids <- names(model$biodiversity)
 
     # create list to store old models
-    if (length(ids) > 1 && method_integration == "predictor") {
+    if (length(ids) > 1 && method_integration == "predictor" && keep_models) {
+      if(getOption('ibis.setupmessages', default = TRUE)) myLog('[Estimation]','yellow','Storing all models in object')
       .internals <- vector(mode = "list", length = length(ids) -1)
       names(.internals) <- ids[-length(ids)]
     } else {
@@ -1023,7 +1026,7 @@ methods::setMethod(
             }
 
             # store result in internals
-            if (!is.Waiver(.internals)) {
+            if (!is.Waiver(.internals) && keep_models) {
               .internals[[id]] <- list(model = out, name = pred_name)
             }
           } else if(method_integration == "offset"){
@@ -1143,7 +1146,7 @@ methods::setMethod(
             }
 
             # store result in internals
-            if (!is.Waiver(.internals)) {
+            if (!is.Waiver(.internals) && keep_models) {
               .internals[[id]] <- list(model = out, name = pred_name)
             }
           } else if(method_integration == "offset"){
@@ -1261,7 +1264,7 @@ methods::setMethod(
             }
 
             # store result in internals
-            if (!is.Waiver(.internals)) {
+            if (!is.Waiver(.internals) && keep_models) {
               .internals[[id]] <- list(model = out, name = pred_name)
             }
           } else if(method_integration == "offset"){
@@ -1405,7 +1408,7 @@ methods::setMethod(
             }
 
             # store result in internals
-            if (!is.Waiver(.internals)) {
+            if (!is.Waiver(.internals) && keep_models) {
               .internals[[id]] <- list(model = out, name = pred_name)
             }
           } else if(method_integration == "offset"){
@@ -1520,7 +1523,7 @@ methods::setMethod(
             }
 
             # store result in internals
-            if (!is.Waiver(.internals)) {
+            if (!is.Waiver(.internals) && keep_models) {
               .internals[[id]] <- list(model = out, name = pred_name)
             }
           } else if(method_integration == "offset"){
@@ -1634,7 +1637,7 @@ methods::setMethod(
             }
 
             # store result in internals
-            if (!is.Waiver(.internals)) {
+            if (!is.Waiver(.internals) && keep_models) {
               .internals[[id]] <- list(model = out, name = pred_name)
             }
           } else if(method_integration == "offset"){
@@ -1714,7 +1717,7 @@ methods::setMethod(
     }
 
     # adding integrated model steps
-    if (!is.Waiver(.internals)) out$.internals <- .internals
+    if (!is.Waiver(.internals) && keep_models) out$.internals <- .internals
 
     # Stop logging if specified
     if(!is.Waiver(x$log)) x$log$close()

--- a/R/train.R
+++ b/R/train.R
@@ -973,9 +973,7 @@ methods::setMethod(
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
         if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- list(fit_best = out$fits$fit_best,
-                                   predictors_names = model2$predictors_names,
-                                   predictors = model2$predictors)
+          .internals[[id]] <- out
         }
         rm(model2, settings2)
 
@@ -1103,9 +1101,7 @@ methods::setMethod(
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
         if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- list(fit_best = out$fits$fit_best,
-                                   predictors_names = model2$predictors_names,
-                                   predictors = model2$predictors)
+          .internals[[id]] <- out
         }
         rm(model2, settings2)
 
@@ -1232,8 +1228,7 @@ methods::setMethod(
         rm(model2, settings2)
         # save previous outs
         if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- list(fit_best = out$fits$fit_best,
-                                   predictors_names = model2$biodiversity[[1]]$predictors_names)
+          .internals[[id]] <- out
         }
 
         # Add Prediction of model to next object if multiple are supplied
@@ -1384,9 +1379,7 @@ methods::setMethod(
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
         if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- list(fit_best = out$fits$fit_best,
-                                   predictors_names = model2$predictors_names,
-                                   predictors = model2$predictors)
+          .internals[[id]] <- out
         }
         rm(model2, settings2)
 
@@ -1508,9 +1501,7 @@ methods::setMethod(
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
         if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- list(fit_best = out$fits$fit_best,
-                                   predictors_names = model2$predictors_names,
-                                   predictors = model2$predictors)
+          .internals[[id]] <- out
         }
         rm(model2, settings2)
 
@@ -1630,9 +1621,7 @@ methods::setMethod(
         # train model and save outputs
         out <- x$engine$train(model2, settings2)
         if (!is.Waiver(.internals) && id != ids[length(ids)]) {
-          .internals[[id]] <- list(fit_best = out$fits$fit_best,
-                                   predictors_names = model2$predictors_names,
-                                   predictors = model2$predictors)
+          .internals[[id]] <- out
         }
         rm(model2, settings2)
 

--- a/R/train.R
+++ b/R/train.R
@@ -173,15 +173,25 @@ methods::setMethod(
       is.logical(clamp),
       is.logical(verbose)
     )
+
     # Now make checks on completeness of the object
-    assertthat::assert_that(!is.Waiver(x$engine),
-                            !is.null(x$engine),
+    assertthat::assert_that(!is.Waiver(x$engine), !is.null(x$engine),
                             msg = 'No engine set for training the distribution model.')
-    assertthat::assert_that( x$show_biodiversity_length() > 0,
-                             msg = 'No biodiversity data specified.')
-    assertthat::assert_that('observed' %notin% x$get_predictor_names(), msg = 'observed is not an allowed predictor name.' )
+    assertthat::assert_that(x$show_biodiversity_length() > 0,
+                            msg = 'No biodiversity data specified.')
+    assertthat::assert_that('observed' %notin% x$get_predictor_names(),
+                            msg = 'observed is not an allowed predictor name.' )
+
+    # check names of biodiv data
+    if (x$show_biodiversity_length() > 1) {
+      if (getOption('ibis.setupmessages', default = TRUE) && length(unique(unlist(x$biodiversity$get_names()))) == 1) {
+        myLog('[Setup]','yellow','It is advised to supply unique biodiversity dataset names')
+      }
+    }
+
     # Messenger
     if(getOption('ibis.setupmessages', default = TRUE)) myLog('[Estimation]','green','Collecting input parameters.')
+
     # --- #
     # filter_predictors = "none"; optim_hyperparam = FALSE; runname = "test";inference_only = FALSE; verbose = TRUE;only_linear=TRUE;method_integration="predictor";aggregate_observations = TRUE; clamp = FALSE
     # Match variable selection

--- a/man/DistributionModel-class.Rd
+++ b/man/DistributionModel-class.Rd
@@ -24,6 +24,8 @@ Could be further pretified and commands outsourced.
 \item{\code{settings}}{A \code{\linkS4class{Settings}} object with information on inference.}
 
 \item{\code{fits}}{A \code{\link{list}} containing the prediction and fitted model.}
+
+\item{\code{.internals}}{A \code{\link{list}} containing previous fitted models.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/train.Rd
+++ b/man/train.Rd
@@ -13,6 +13,7 @@ train(
   inference_only = FALSE,
   only_linear = TRUE,
   method_integration = "predictor",
+  keep_models = TRUE,
   aggregate_observations = TRUE,
   clamp = FALSE,
   verbose = getOption("ibis.setupmessages", default = TRUE),
@@ -27,6 +28,7 @@ train(
   inference_only = FALSE,
   only_linear = TRUE,
   method_integration = "predictor",
+  keep_models = TRUE,
   aggregate_observations = TRUE,
   clamp = TRUE,
   verbose = getOption("ibis.setupmessages", default = TRUE),
@@ -91,6 +93,9 @@ then combined for estimation and weighted respectively, thus giving for example
 presence-only records less weight than survey records. \strong{Note} that this parameter
 is ignored for engines that support joint likelihood estimation.
 }}
+
+\item{keep_models}{\code{\link{logical}} if true and \code{method_integration = "predictor"},
+all models are stored in the \code{.internal} list of the model object.}
 
 \item{aggregate_observations}{\code{\link{logical}} on whether observations covering the
 same grid cell should be aggregated (Default: \code{TRUE}).}


### PR DESCRIPTION
This PR allows to project models that were trained using `method_integration = "predictor"` related to #106. 

The idea is to store all integrated models in the `$.internals` list. This increases the object size, however, I don't see any other possibility due to the design of the package. Within the `project()` function, the projections are done using `fit$project(...)` which is a generic for the class `DistributionModel` and the specific engine. Thus, storing only the data, formula, fits, etc. would need a lot of structural code changes and most likely some hard-to-maintain code repetitions (one `fit$project(...)` for `DistributionModel` and `internals$project(...)` one similar for data only).

P.S. This already includes the latest bug fixes to `dev`

